### PR TITLE
Improvements for CCC-slides

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,18 +370,20 @@
         </div>
     </div> <!-- second text box -->
 
+    <!-- slides -->
     <div class="container-fluid slides-container">
         <div class="col-lg-push-2 col-lg-8 col-sm-12">
-            <h2>Slides from <a href="https://events.ccc.de/congress/2016/wiki/Session:NewPipe">33C3</a></h2>
+            <h3 class="text-center">Slides from <a href="https://events.ccc.de/congress/2016/wiki/Session:NewPipe">33C3</a></h3>
             <embed class="pad-bottom" width="100%" height="512px" src="pdf/NewPipe_presentation.pdf" type="application/pdf"/>
             <p class="text-center slides-download">
                 <a href="pdf/NewPipe_presentation.pdf">Download as PDF</a>
             </p>
         </div>
-    </div>
+    </div> <!-- slides-container -->
 
     <!-- footer -->
     <footer class="footer">
+        <div class="image-puffer"></div>
         <div class="container">
             <div class="image-holder">
                 <img src="img/logo-white-border.png" class="footer-logo" />

--- a/index.html
+++ b/index.html
@@ -311,19 +311,6 @@
 
             </div> <!-- gallery -->
 
-            <!-- presentation box --->
-            <div class="presentation">
-                <div class="container">
-                    <div class="row">
-                        <div class="col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2 text-center">
-                            <p><strong class="extra">You want to know even more about NewPipe?</strong></p>
-                            <p>Check out our presentation from the 33C3</p>
-                            <p><a href="pdf/NewPipe_presentation.pdf"><button class="moreInfo">more info</button></a></p>
-                        </div>
-                    </div>
-                </div>
-            </div> <!-- presentation -->
-
         </div> <!-- features -->
 
     </div> <!-- features-wrapper -->
@@ -369,14 +356,16 @@
 
         </div>
     </div> <!-- second text box -->
-
+    
     <!-- slides -->
     <div class="container-fluid slides-container">
         <div class="col-lg-push-2 col-lg-8 col-sm-12">
             <h3 class="text-center">Slides from <a href="https://events.ccc.de/congress/2016/wiki/Session:NewPipe">33C3</a></h3>
-            <embed class="pad-bottom" width="100%" height="512px" src="pdf/NewPipe_presentation.pdf" type="application/pdf"/>
+            <embed class="pad-bottom slides" width="100%" height="512px" src="pdf/NewPipe_presentation.pdf" type="application/pdf"/>
             <p class="text-center slides-download">
-                <a href="pdf/NewPipe_presentation.pdf">Download as PDF</a>
+                <br class="visible-xs-inline">
+                <br class="visible-xs-inline">
+                <a href="pdf/NewPipe_presentation.pdf" download>Download as PDF</a>
             </p>
         </div>
     </div> <!-- slides-container -->

--- a/style.css
+++ b/style.css
@@ -289,21 +289,6 @@ a:hover {
 .features-wrapper .row > div  > * {
     height: auto;
 }
-.features .presentation {
-    padding-top: 15px;
-}
-.features .presentation .moreInfo {
-    background: #aaaaaa;
-    border: none;
-    margin: 1.5px 2px;
-    padding: 6px 8.5px;
-    color: white;
-    border-radius: 15px;
-}
-.features .presentation .moreInfo:hover {
-    margin: 0;
-    padding: 7.5px 10.5px;
-}
 @media (max-width: 767px){
     .features-background {
         background-position: center top;
@@ -320,8 +305,8 @@ a:hover {
 .text-2 {
     text-align: center;
     padding-top: 40px;
-    padding-bottom: 70px;
-    background: #f4f2f5;
+    padding-bottom: 30px;
+    background: #f3eff2;
 }
 .text-2 a {
     color: #cd201f;
@@ -354,6 +339,9 @@ strong.extra {
     background: #AA1D1D;
 }
 @media (max-width: 767px){
+    .text-2 {
+        padding-bottom: 30px;
+    }
     .text-2 .row {
         padding-left: 15px;
         padding-right: 15px;
@@ -364,19 +352,42 @@ strong.extra {
 /* Slides */
 
 .slides-container {
-    background-color: #d0d0d0;
+    padding-top: 20px;
+    background-color: #d0cdcd;
+    border-top: 2px solid white;
 }
 .slides-container a {
     color: #cd201f;
 }
 .slides-container h3 {
-    margin-bottom: 15px;
+    margin-top: 20px;
+    margin-bottom: 0;
+    font-size: 125%;
+    font-weight: 700;
 }
 .slides-container .slides-download {
-    margin-top: 12px;
-    margin-bottom:20px;
+    margin-top: 0;
+    margin-bottom: 20px;
 }
-
+.slides-container embed.slides {
+    display: none;
+}
+@media (min-width: 768px) {
+    .slides-container {
+        padding-top: 0;
+        border-top: none;
+    }
+    .slides-container h3 {
+        margin-bottom: 15px;
+    }
+    .slides-container .slides-download {
+        margin-top: 15px;
+        margin-bottom: 20px;
+    }
+    .slides-container embed.slides {
+        display: initial;
+    }
+}
 
 /* Footer */
 
@@ -399,7 +410,7 @@ strong.extra {
 }
 .footer .image-puffer {
     padding-bottom: 70px;
-    background-color:#d0d0d0;
+    background-color:#d0cdcd;
 }
 .footer-logo {
     height: 90px;

--- a/style.css
+++ b/style.css
@@ -212,7 +212,7 @@ a:hover {
 /* TEXT-1 */
 
 .text-1 {
-    background: #f4f2f5;
+    background: #f3eff2;
     padding-top: 50px;
     padding-bottom: 15px;
 }

--- a/style.css
+++ b/style.css
@@ -45,13 +45,7 @@
 a:hover {
     text-decoration: none;
 }
-.slides-container {
-    background-color: #afafb2;
-}
-.slides-container .slides-download {
-    margin-top: 12px;
-    margin-bottom:20px;
-}
+
 
 /* Header */
 

--- a/style.css
+++ b/style.css
@@ -17,9 +17,7 @@
         padding-right: 60px;
     }
 }
-.text-justify-xs {
-    text-align: justify;
-}
+
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {
     .text-justify-sm {
@@ -126,7 +124,6 @@ a:hover {
     left: 7.7px;
     width: calc(328 / 553 * 350px);
 }
-
 @media (max-width: 767px){
     .header-box-wrapper .pull-left {
         float: none !important;
@@ -146,7 +143,6 @@ a:hover {
         right: 0;
     }
 }
-
 @media (min-width: 768px){
     .header-text {
         margin-bottom: 100px;
@@ -365,18 +361,33 @@ strong.extra {
 }
 
 
+/* Slides */
+
+.slides-container {
+    background-color: #d0d0d0;
+}
+.slides-container a {
+    color: #cd201f;
+}
+.slides-container h3 {
+    margin-bottom: 15px;
+}
+.slides-container .slides-download {
+    margin-top: 12px;
+    margin-bottom:20px;
+}
+
+
 /* Footer */
 
 .footer {
     background: #AA1D1D/*#CD322E*/;
     width: 100%;
     min-height: 170px;
-    margin-top: 64px;
 }
 .footer-copyright {
     margin: 0 0 25px 0;
 }
-
 .footer, .footer-links, .footer-links a, .footer-links a:hover, .footer .copyright {
     color: white;
     text-decoration: none;
@@ -386,12 +397,15 @@ strong.extra {
     position: relative;
     top: -45px;
 }
+.footer .image-puffer {
+    padding-bottom: 70px;
+    background-color:#d0d0d0;
+}
 .footer-logo {
     height: 90px;
     margin:0;
     padding: 0;
 }
-
 @media (max-width: 767px){
     .navbar-header > .navbar-toggle, .navbar-header > .navbar-toggle:hover, .navbar-header > .navbar-toggle:focus {
         border: none;


### PR DESCRIPTION
This PR

- removes the `.presentation` container

- improves `background-color` of `.text-1` , `.text-2` and `.slides-container`

- forces the browser to download the PDF file instead of opening it in another tab after clicking on the "Download as PDF" link

Note: The background colors of the containers are not the same as [these](https://github.com/TeamNewPipe/website/issues/10#issuecomment-294606308) shown in #10. They clashed a little.