### PR TITLE
Search & post excerpts improvements

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ description: > # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "" # /press/_site # the subpath of your site, e.g. /blog
-url: "" # http://186.182.2.102/ # the base hostname & protocol for your site, e.g. http://example.com
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
 github_username:  TeamNewPipe
 
 # Build settings

--- a/blog/index.html
+++ b/blog/index.html
@@ -24,7 +24,10 @@ short: All posts
             {% if post.excerpt_separator %}
                 {{ post.excerpt }}
             {% else %}
-                {{ post.content | truncatewords:100 }}
+                {%- assign exc = post.content | normalize_whitespace | split: '</p>' -%}
+                {%- for excs in exc -%}
+                {%- if forloop.index < 3 -%}{{ excs | append : '</p>'}}{%- endif -%}
+                {%- endfor -%}
             {% endif %}
             <p><a href="{{ post.url }}">Read more...</a></p>
         </div>

--- a/lunrjs/blog_search.js
+++ b/lunrjs/blog_search.js
@@ -13,14 +13,14 @@ function displaySearchResults(results, store) {
         for (var i = 0; i < results.length; i++) {  // Iterate over the results
             var item = store[results[i].ref];
             appendString += '<div class="border-box anchor-right-full-parent">'
-                          + '<h4><a href="' + item.url + '">' + item.title + '</a></h4>'
-                          +  '<p><span>' + item.date+ ', by ' + item.author + '</span></p><br>'
-                          + item.content.split(/\s+/).slice(0,100).join(" ") + '...<br>'
-                          + '<p><a href="' + item.url + '">Read more...</a></p>';
+                    + '<h4><a href="' + item.url + '">' + item.title + '</a></h4>'
+                    + '<p><span>' + item.date+ ', by ' + item.author + '</span></p><br>'
+                    + item.excerpt + '<br>'
+                    + '<p><a href="' + item.url + '">Read more...</a></p>';
             if(item.category.length != 0){
                 appendString += '<p class="categories">';
                 for(var c = 0; c < item.category.length; c++){
-                    appendString += '<a href="/' + siteBaseUrl +  item.category[c].toLowerCase() + '"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;' +  item.category[c] + '</a>';
+                    appendString += '<a href="/' + siteBaseUrl + item.category[c].toLowerCase() + '"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;' + item.category[c] + '</a>';
                     if(item.category.length - c != 1) //not the last item
                         appendString += " &nbsp;|&nbsp; ";
                 }
@@ -68,6 +68,7 @@ function search(type){
             this.field('category', { boost: 5 });
             this.field('date');
             this.field('content');
+            this.field('excerpt', { boost: 2 });
         });
 
         for (var key in window.store) { // Add the data to lunr
@@ -77,7 +78,8 @@ function search(type){
                 'author': window.store[key].author,
                 'category': window.store[key].category,
                 'date': window.store[key].date,
-                'content': window.store[key].content
+                'content': window.store[key].content,
+                'excerpt': window.store[key].excerpt
             });
 
             var results = idx.search(searchTerm); // Get lunr to perform a search

--- a/lunrjs/blog_search.js
+++ b/lunrjs/blog_search.js
@@ -13,10 +13,24 @@ function displaySearchResults(results, store) {
         for (var i = 0; i < results.length; i++) {  // Iterate over the results
             var item = store[results[i].ref];
             appendString += '<div class="border-box anchor-right-full-parent">'
-                    + '<h4><a href="' + item.url + '">' + item.title + '</a></h4>'
-                    + '<p><span>' + item.date+ ', by ' + item.author + '</span></p><br>'
-                    + item.excerpt + '<br>'
+                + '<h4><a href="' + item.url + '">' + item.title + '</a></h4>'
+                + '<p><span>' + item.date+ ', by ' + item.author + '</span></p><br>';
+            if (item.image != "") {
+                appendString += '<div class="row">\n'
+                    + '        <a href="{{ BASE_PATH }}{{ post.url }}">\n'
+                    + '            <div class="col-md-3 col-img">\n'
+                    + '                <img src="' + item.image + '" class="img-responsive postImg" />\n'
+                    + '            </div>\n'
+                    + '        </a>\n'
+                    + '        <div class="col-md-9">'
+                    + '            ' + item.excerpt
+                    + '<p><a href="' + item.url + '">Read more...</a></p>'
+                    + '        </div>'
+                    + '    </div>';
+            } else {
+                appendString += item.excerpt
                     + '<p><a href="' + item.url + '">Read more...</a></p>';
+            }
             if(item.category.length != 0){
                 appendString += '<p class="categories">';
                 for(var c = 0; c < item.category.length; c++){
@@ -27,7 +41,7 @@ function displaySearchResults(results, store) {
                 appendString += "</p>";
             }
             appendString += '<div class="anchor-right-full"></div>'
-                          + '</div>';
+                + '</div>';
         }
 
         searchResults.innerHTML = appendString;

--- a/lunrjs/blog_searchData.js
+++ b/lunrjs/blog_searchData.js
@@ -28,7 +28,8 @@ window.store = {
           {%- if forloop.index < 3 -%}{{ excs | append : '</p>'}}{%- endif -%}
         {%- endfor -%}
       {%- endcapture -%}{{ e |jsonify }}
-      {%- endif -%},
+    {%- endif -%},
+    "image": "{% if post.image %}/img/{{ site.data.images[post.image].url }}{% endif %}",
     "url": "{{ post.url | xml_escape }}"
   }{%- unless forloop.last -%},{%- endunless -%}
 {% endfor %}

--- a/lunrjs/blog_searchData.js
+++ b/lunrjs/blog_searchData.js
@@ -1,15 +1,35 @@
 ---
-
+# Generates the data for the search as JSON
+#
+# There were some problems using Jekyll's "excerpt" variable which returns an excerpt of the post.
+# By default that excerpt just captures the first paragraph of the post.
+# There is the possibility to set the number of paragraphs an excerpt contains in EVERY SINGLE post.
+# That is not flexible and good when there is a larger number of posts.
+# Because we want two paragraphs we needed this hack.
+#
+# Basically this takes the whole content of the post, splits it at the end of each paragraph
+# and only prints the first two.
 ---
 window.store = {
-{% for post in site.posts %}
+{%- for post in site.posts -%}
   "{{ post.url | slugify }}": {
     "title": "{{ post.title | xml_escape }}",
     "author": "{{ post.author | xml_escape }}",
     "category": [{% for category in post.categories %}"{{ category }}"{% unless forloop.last %},{% endunless %}{% endfor %}],
     "date": "{{ post.date | date_to_string }}",
     "content": {{ post.content | strip_newlines | jsonify }},
+    "excerpt":
+    {%- if post.excerpt_separator -%}
+      {{ post.excerpt | normalize_whitespace | jsonify | replace: '\n', '' | prepend: ' '}}
+    {%- else -%}
+      {%- capture e -%}
+        {%- assign exc = post.content | normalize_whitespace | split: '</p>' -%}
+        {%- for excs in exc -%}
+          {%- if forloop.index < 3 -%}{{ excs | append : '</p>'}}{%- endif -%}
+        {%- endfor -%}
+      {%- endcapture -%}{{ e |jsonify }}
+      {%- endif -%},
     "url": "{{ post.url | xml_escape }}"
-  }{% unless forloop.last %},{% endunless %}
+  }{%- unless forloop.last -%},{%- endunless -%}
 {% endfor %}
 };

--- a/lunrjs/press_searchData.js
+++ b/lunrjs/press_searchData.js
@@ -1,18 +1,17 @@
 ---
 
 ---
-
 window.store = {
-{% for page in site.html_pages %}
-{% if page.search != 'exclude' %}
-{% if page.title and page.date %}
+{%- for page in site.html_pages -%}
+{%- if page.search != 'exclude' -%}
+{%- if page.title and page.date -%}
   "{{ page.url | slugify }}": {
     "title": "{{ page.title | xml_escape }}",
     "date": "{{ page.date | date_to_string }}",
-    "content": {{ page.content | strip_newlines | jsonify }},
+    "content": {{ page.content | normalize_whitespace | jsonify }},
     "url": "{{ page.url | xml_escape }}"
   }{% unless forloop.last %},{% endunless %}
-{% endif %}
-{% endif %}
-{% endfor %}
+{%- endif -%}
+{%- endif -%}
+{%- endfor -%}
 };


### PR DESCRIPTION
I added the excerpts to the search. Unfortunately, Jekyll does not yet allow a global setting for the number of paragraphs which will be returned as excerpt. That's why this was a little tricky. I hope the result looks like what you requested @TheAssassin.
Besides that I added the images to the search results.