### PR TITLE
Use TeamNewPipe/web-api instead of GitHub API

### DIFF
--- a/js/github-api.js
+++ b/js/github-api.js
@@ -5,7 +5,7 @@
  */
 function latestVersion(tag = false) {
     var xhttp = new XMLHttpRequest();
-    xhttp.open("GET", "https://api.github.com/repos/TeamNewPipe/NewPipe/releases/latest", false);
+    xhttp.open("GET", "https://newpipe.schabi.org/api/current-version", false);
     xhttp.send();
-    return (tag) ? $.parseJSON(xhttp.responseText)["name"].substr(1) : $.parseJSON(xhttp.responseText)["name"];
+    return (tag) ?xhttp.responseText.substr(1) : xhttp.responseText;
 }


### PR DESCRIPTION
Use TeamNewPipe/web-api instead of GitHub API to get the current stable version.
I almost forgot to do this.
See https://github.com/TeamNewPipe/website/commit/91a3df8ead7ac1e547bb3ab16439c0e562532da7#commitcomment-27490035 for more info.