### PR TITLE
Press & Blog Improvements

### DIFF
--- a/_data/images.yml
+++ b/_data/images.yml
@@ -27,6 +27,7 @@ newpipe-beta:
   name: NewPipe Beta logo
   author: Schabi
   origin: https://github.com/theScrabi
+  download: /press/logo/#logo-beta
 
 speech-bubbles:
   url: speech_bubbles.svg

--- a/_includes/blog_page_end.html
+++ b/_includes/blog_page_end.html
@@ -1,3 +1,4 @@
+</div> <!-- page -->
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <script src="{{ site.baseurl }}/bootstrap/js/bootstrap.min.js"></script>
 
@@ -36,6 +37,25 @@
             }
         });
     </script>
-</div>
+
+
+    <script>
+        /**
+         * Corrects the window scroll position
+         * because the fixed nav bar needs some space on the top.
+         * This makes navigation via HTML anchors difficult,
+         * because a part of the elemnt is hidden behind the navigation bar.
+         */
+        function correctAnchors() {
+            var hash = window.location.hash.substr(1);
+            if (typeof hash == 'undefined' || hash === "" || hash == null) return;
+            var top = $("#" + hash).offset().top;
+            var nav = $("#header").outerHeight(true);
+            window.scrollTo(0, top - nav);
+        }
+        $(window).on("load", correctAnchors);
+        $(window).on('hashchange', correctAnchors);
+    </script>
+
 </body>
 </html>

--- a/_includes/press_footer.html
+++ b/_includes/press_footer.html
@@ -22,5 +22,23 @@
 <!-- Include all compiled plugins (below), or include individual files as needed -->
 <script src="{{ site.baseurl }}/bootstrap/js/bootstrap.min.js"></script>
 
+<script>
+    /**
+     * Corrects the window scroll position
+     * because the fixed nav bar needs some space on the top.
+     * This makes navigation via HTML anchors difficult,
+     * because a part of the elemnt is hidden behind the navigation bar.
+     */
+    function correctAnchors() {
+        var hash = window.location.hash.substr(1);
+        if (typeof hash == 'undefined' || hash === "" || hash == null) return;
+        var top = $("#" + hash).offset().top;
+        var nav = $("#header").outerHeight(true);
+        window.scrollTo(0, top - nav);
+    }
+    $(window).on("load", correctAnchors);
+    $(window).on('hashchange', correctAnchors);
+</script>
+
 </body>
 </html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,7 +18,7 @@ layout: blog_with-sidebar-post
     <div class="post-content text-justify-sm" itemprop="articleBody">
         {% if page.image %}
         <div class="row">
-            <div class="col-md-3 col-img" onclick="viewMediaFile(this)" data-toggle="modal" data-target="#mediaFileView">
+            <div class="col-md-3 col-img">
                 {% assign image = site.data.images[page.image] %}
                 <img src="/img/{{ image.url }}" class="img-responsive postImg" />
                 By <a href="{{ image.origin }}">{{ image.author }}</a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -26,19 +26,27 @@ layout: blog_with-sidebar-post
             </div>
             <div class="col-md-9">
                 {{ content }}
+                <div class="post-categories">
+                    See also:
+                    {% for category in page.categories %}
+                    <a href="{{ site.baseurl}}/blog/{{ category | slugize }}"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;{{ category }}</a>
+                    {% unless forloop.last %}&nbsp;|&nbsp;{% endunless %}
+                    {% endfor %}
+                </div>
             </div>
         </div>
         {% else %}
         {{ content }}
-        {% endif %}
-    </div>
 
-    <div class="post-categories">
-        See also: 
-        {% for category in page.categories %}
-        <a href="{{ site.baseurl}}/blog/{{ category | slugize }}"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;{{ category }}</a>
-        {% unless forloop.last %}&nbsp;|&nbsp;{% endunless %}
-        {% endfor %}
+        <div class="post-categories">
+            See also:
+            {% for category in page.categories %}
+            <a href="{{ site.baseurl}}/blog/{{ category | slugize }}"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;{{ category }}</a>
+            {% unless forloop.last %}&nbsp;|&nbsp;{% endunless %}
+            {% endfor %}
+        </div>
+
+        {% endif %}
     </div>
 
     <!-- Modal -->

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,15 +1,11 @@
 ---
-# You don't need to edit this file, it's empty on purpose.
-# Edit theme's home layout instead if you wanna make some changes
-# See: https://jekyllrb.com/docs/themes/#overriding-theme-defaults
 title: a free YouTube client - HOME
 layout: blog_with-sidebar
 description: Welcome to NewPipe!
 short: All posts
-
 ---
 {% for post in paginator.posts %}
-<!--{{ post.author }}-->
+
 <div class="border-box anchor-right-full-parent">
     <h4><a href="{{ BASE_PATH }}{{ post.url }}">{{ post.title }}</a></h4>
     <p><span>{{ post.date | date_to_string }}, by {{ post.author }}</span></p><br>
@@ -30,6 +26,12 @@ short: All posts
                 {%- endfor -%}
             {% endif %}
             <p><a href="{{ post.url }}">Read more...</a></p>
+            <p class="categories">
+                {% for category in post.categories %}
+                <a href="{{ site.baseurl }}/blog/{{ category | slugize }}"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;{{ category }}</a>
+                {% unless forloop.last %}&nbsp;|&nbsp;{% endunless %}
+                {% endfor %}
+            </p>
         </div>
     </div>
     {% else %}
@@ -39,14 +41,16 @@ short: All posts
             {{ post.content | truncatewords:100 }}
         {% endif %}
         <p><a href="{{ post.url }}">Read more...</a></p>
+
+        <p class="categories">
+            {% for category in post.categories %}
+            <a href="{{ site.baseurl }}/blog/{{ category | slugize }}"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;{{ category }}</a>
+            {% unless forloop.last %}&nbsp;|&nbsp;{% endunless %}
+            {% endfor %}
+        </p>
+
     {% endif %}
 
-    <p class="categories">
-        {% for category in post.categories %}
-        <a href="{{ site.baseurl }}/blog/{{ category | slugize }}"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;{{ category }}</a>
-        {% unless forloop.last %}&nbsp;|&nbsp;{% endunless %}
-        {% endfor %}
-    </p>
     <div class="anchor-right-full"></div>
 </div>
 {% endfor %}

--- a/css/blog.css
+++ b/css/blog.css
@@ -566,6 +566,9 @@ strong.extra {
         padding-right: 5px;
         padding-bottom: 0;
     }
+    .post-categories {
+        margin-top: 15px;
+    }
 }
 @media (max-width: 767px){
     .post-collection {

--- a/css/blog.css
+++ b/css/blog.css
@@ -753,6 +753,10 @@ div.search-container button:focus, div.search-container input:focus {
 Allowed HTML Tags
 h5, h6, 
 */
+#isso-thread .textarea:focus,
+#isso-thread input:focus {
+    border-color: #AA1D1D;
+}
 #comments {
     margin-top: 20px;
     #background: #f3eff2;
@@ -769,7 +773,14 @@ h5, h6,
     margin-left: -30px;
     margin-bottom: 15px;
 }
-
+#comments .isso-postbox > .form-wrapper > .auth-section .post-action > input {
+    background: white;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+#comments .isso-postbox > .form-wrapper > .auth-section .post-action:hover > input {
+    border-color: #AA1D1D;
+}
 #comments h1, #comments h2, #comments h3, #comments h4 {
     font-size: 18px;
 }

--- a/css/blog.css
+++ b/css/blog.css
@@ -574,6 +574,9 @@ strong.extra {
     .post-collection {
         padding-top: 20px;
     }
+    .postImg {
+        max-height: 33vh;
+    }
 }
 .postImg[src*=".svg"] {
     width: 100%;

--- a/css/comments.css
+++ b/css/comments.css
@@ -242,34 +242,4 @@
     }
 }
 
-/* Custom styles */
-#comments {
-    margin-top: 20px;
-    #background: #f3eff2;
-}
-#comments > h4 {
-    font-weight: bold;
-    margin-top: 50px;
-    margin-bottom: 30px;
-}
-#comments-separator {
-    width: calc(100% + 60px);
-    border-top: 2px solid white;
-    margin-top: 10px;
-    margin-left: -30px;
-    margin-bottom: 15px;
-}
 
-#comments h1, #comments h2, #comments h3, #comments h4 {
-    font-size: 18px;
-}
-@media (min-width: 767px) {
-    .comments-separator {
-        width: calc(100% + 15px);
-        margin-left: 0;
-    }
-    #comments > h4 {
-        margin-top: 60px;
-        margin-bottom: 75px;
-    }
-}

--- a/css/press.css
+++ b/css/press.css
@@ -290,6 +290,9 @@ p.subtitle {
 #announcements article .press-date {
     font-size: 80%;
 }
+#announcements article img.postImg {
+    margin: 0 auto 15px;
+}
 
 /* Search */
 #search-results {

--- a/css/press.css
+++ b/css/press.css
@@ -12,14 +12,14 @@
         linear-gradient(to right, rgba(0,0,0,0.0) calc(100% - ((100% - 1170px) / 2)), rgba(0,0,0,0.1) 100% );
 }
 #header {
-    -webkit-box-shadow: 0px 4px 4px 0px rgba(0,0,0,0.175);
-    -moz-box-shadow: 0px 4px 4px 0px rgba(0,0,0,0.175);
-    box-shadow: 0px 4px 4px 0px rgba(0,0,0,0.175);
+    -webkit-box-shadow: 0 4px 4px 0 rgba(0,0,0,0.175);
+    -moz-box-shadow: 0 4px 4px 0 rgba(0,0,0,0.175);
+    box-shadow: 0 4px 4px 0 rgba(0,0,0,0.175);
 }
 .footer .shadow-top {
-    -webkit-box-shadow: 0px -4px 4px 0px rgba(0,0,0,0.175);
-    -moz-box-shadow: 0px -4px 4px 0px rgba(0,0,0,0.175);
-    box-shadow: 0px -4px 4px 0px rgba(0,0,0,0.175);
+    -webkit-box-shadow: 0 -4px 4px 0 rgba(0,0,0,0.175);
+    -moz-box-shadow: 0 -4px 4px 0 rgba(0,0,0,0.175);
+    box-shadow: 0 -4px 4px 0 rgba(0,0,0,0.175);
 }
 .navbar-fixed-top ~ .site-content {
     margin-top: 64px;
@@ -256,14 +256,29 @@ p.subtitle {
 }
 #welcome h4 {
     margin-top: 25px;
+    color: #333;
+}
+#welcome strong {
+    color: #333;
 }
 #welcome p {
     text-align: justify;
+    line-height: 1.5;
 }
-@media (min-width: 767px){
+#welcome ul {
+    margin-bottom: 15px;
+    padding-inline-start: 11px;
+}
+@media (min-width: 767px) {
+    #welcome {
+        font-size: 15px;
+    }
     #welcome ul {
         list-style-position: inside;
         padding-left: 0;
+    }
+    #welcome ul li.linebreak {
+        text-indent: -11px; margin-left: 11px;
     }
 }
 #announcements article {
@@ -272,7 +287,7 @@ p.subtitle {
     margin-bottom: 25px;
     position: relative;
 }
-#announcements article .press-date{
+#announcements article .press-date {
     font-size: 80%;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 html, body {
-    height: 100%;
+    min-height: 100%;
     font-family: Arial;
 }
 body.modal-open {
@@ -898,7 +898,7 @@ body.modal-open {
 #page {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    min-height: 100%;
     background: #d0cdcd;
 }
 #header, #footer {

--- a/lunrjs/blog_search.js
+++ b/lunrjs/blog_search.js
@@ -17,7 +17,7 @@ function displaySearchResults(results, store) {
                 + '<p><span>' + item.date+ ', by ' + item.author + '</span></p><br>';
             if (item.image != "") {
                 appendString += '<div class="row">\n'
-                    + '        <a href="{{ BASE_PATH }}{{ post.url }}">\n'
+                    + '        <a href="' + item.url + '">\n'
                     + '            <div class="col-md-3 col-img">\n'
                     + '                <img src="' + item.image + '" class="img-responsive postImg" />\n'
                     + '            </div>\n'

--- a/lunrjs/blog_search.js
+++ b/lunrjs/blog_search.js
@@ -25,29 +25,37 @@ function displaySearchResults(results, store) {
                     + '        <div class="col-md-9">'
                     + '            ' + item.excerpt
                     + '<p><a href="' + item.url + '">Read more...</a></p>'
+                    + getCategories(item)
                     + '        </div>'
-                    + '    </div>';
+                    + '    </div>'; // row
             } else {
                 appendString += item.excerpt
-                    + '<p><a href="' + item.url + '">Read more...</a></p>';
+                    + '<p><a href="' + item.url + '">Read more...</a></p>'
+                    + getCategories(item);
             }
-            if(item.category.length != 0){
-                appendString += '<p class="categories">';
-                for(var c = 0; c < item.category.length; c++){
-                    appendString += '<a href="/' + siteBaseUrl + item.category[c].toLowerCase() + '"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;' + item.category[c] + '</a>';
-                    if(item.category.length - c != 1) //not the last item
-                        appendString += " &nbsp;|&nbsp; ";
-                }
-                appendString += "</p>";
-            }
+
             appendString += '<div class="anchor-right-full"></div>'
-                + '</div>';
+                + '</div>'; // border-box
         }
 
         searchResults.innerHTML = appendString;
     } else {
         searchResults.innerHTML = '<div id="no-search-results"><br><p class="text-center"><i class="fa fa-3x fa-meh-o" aria-hidden="true"></i><br><br>No results found</p><br></div>';
     }
+}
+
+function getCategories(item) {
+    var categ = "";
+    if(item.category.length != 0) {
+        categ += '<p class="categories">';
+        for(var c = 0; c < item.category.length; c++) {
+            categ += '<a href="/' + siteBaseUrl + item.category[c].toLowerCase() + '"><i class="fa fa-tag" aria-hidden="true"></i>&nbsp;' + item.category[c] + '</a>';
+            if(item.category.length - c != 1) //not the last item
+                categ += " &nbsp;|&nbsp; ";
+        }
+        categ += "</p>";
+    }
+    return categ;
 }
 
 function getQueryVariable(variable) {

--- a/press/announcements.html
+++ b/press/announcements.html
@@ -38,7 +38,7 @@ metatitle: "Announcements - NewPipe a free YouTube client"
 
             <div class="alert alert-warning download-license-warning" role="alert">
                 <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
-                For announcements which were made <b>before</b> 18th December 2017 please visit our GitHub <a href="https://github.com/TeamNewPipe/NewPipe/issues">issue page</a>.
+                For announcements which were made <b>before</b> 18th December 2017 please visit our GitHub <a href="https://github.com/TeamNewPipe/NewPipe/issues?utf8=%E2%9C%93&q=label%3Aannouncement">issue page</a>.
             </div>
 
             <p id="last-modified">Last modified: March 2018</p>

--- a/press/announcements.html
+++ b/press/announcements.html
@@ -41,7 +41,7 @@ metatitle: "Announcements - NewPipe a free YouTube client"
                 For announcements which were made <b>before</b> 18th December 2017 please visit our GitHub <a href="https://github.com/TeamNewPipe/NewPipe/issues">issue page</a>.
             </div>
 
-            <p id="last-modified">Last modified: December 2017</p>
+            <p id="last-modified">Last modified: March 2018</p>
 
         </div>
     </div>

--- a/press/announcements.html
+++ b/press/announcements.html
@@ -21,7 +21,9 @@ metatitle: "Announcements - NewPipe a free YouTube client"
                 <div class="row">
                     <a href="{{ BASE_PATH }}{{ post.url }}">
                         <div class="col-md-3 col-img">
+                            {% if site.data.images[post.image].download %}<a href="{{ site.data.images[post.image].download }}">{% endif %}
                             <img src="/img/{{ site.data.images[post.image].url }}" class="img-responsive postImg" />
+                            {% if site.data.images[post.image].download %}</a>{% endif %}
                         </div>
                     </a>
                     <div class="col-md-9">
@@ -33,6 +35,11 @@ metatitle: "Announcements - NewPipe a free YouTube client"
                 {% endif %}
             </article>
             {% endfor %}
+
+            <div class="alert alert-warning download-license-warning" role="alert">
+                <span class="glyphicon glyphicon-alert" aria-hidden="true"></span>
+                For announcements which were made <b>before</b> 18th December 2017 please visit our GitHub <a href="https://github.com/TeamNewPipe/NewPipe/issues">issue page</a>.
+            </div>
 
             <p id="last-modified">Last modified: December 2017</p>
 

--- a/press/contact.html
+++ b/press/contact.html
@@ -6,7 +6,7 @@ metatitle: "Contact - NewPipe a free YouTube client"
 ---
 
 <main class="content">
-    <div id="welcome" class="background-gray">
+    <div id="contact" class="background-gray">
         <div class="container">
             <h3 class="red start">Contact</h3>
 

--- a/press/index.html
+++ b/press/index.html
@@ -12,31 +12,29 @@ metatitle: "Press information - NewPipe a free YouTube client"
             <!--<p class="subtitle">This is the right place to find any information about NewPipe.</p>-->
             <h4>About NewPipe</h4>
             <p>NewPipe is an Open Source streaming client for Android. Our goal is to provide a privacy friendly access to existing streaming services like YouTube. The app is designed in such a way that it only transports information necessary for playing the media to external servers and thus protects the privacy of its users.</p>
-            <p>A good user experience is important to the developers of NewPipe. Therefore the app offers many solutions for all possible situations. In this way, the resolution and codecs of the video and audio can be set to save data volume in mobile networks. Likewise, NewPipe's video popup and background players make it possible to seamlessly integrate videos and music into daily mobile phone use.</p>
+            <p style="margin-bottom: 15px;">A good user experience is important to the developers of NewPipe. Therefore the app offers many solutions for all possible situations. In this way, the resolution and codecs of the video and audio can be set to save data volume in mobile networks. Likewise, NewPipe's video popup and background players make it possible to seamlessly integrate videos and music into daily mobile phone use.</p>
             <p><strong>Quick information:</strong></p>
-            <!--<div class="row">
-                <div class="col-sm-3">Initial release:</div>
-                <div class="col-sm-9">4. September 2015</div>
-                <div class="col-sm-3">Available languages:</div>
-                <div class="col-sm-9">41</div>
-            </div>-->
-            <ul style="list-style-position: outside;">
+            <ul>
                 <li>Current stable version: <span id="current-version">0.11.5 (Effective 11th February 2018)</span></li>
                 <li>Initial release: 4. September 2015</li>
                 <li>Founder: Christian Schabesberger</li>
-                <li>Available translations: 43<br>You can find a list with all current supported languages at <a href="https://hosted.weblate.org/projects/newpipe/#languages" target="_blank">Weblate</a>.</li>
+                <li class="linebreak">Available translations: 43<br>You can find a list with all current supported languages at <a href="https://hosted.weblate.org/projects/newpipe/#languages" target="_blank">Weblate</a>.</li>
                 <li>Contributors: 186</li>
                 <li>App store: <a href="https://f-droid.org/packages/org.schabi.newpipe/" target="_blank">F-Droid</a></li>
             </ul>
             <p>Because NewPipe and F-Droid guarantee high privacy standards to their users, we cannot give you any information about the number of downloads, active installations or the countries where our users come from, because we do not collect it.</p><!-- But there is a little information about these common indicators for an app popularity: ... -->
 
+            <hr class="separator" />
+
             <h4>About NewPipe Extractor</h4>
             <p>NewPipe Extractor is the system independent core part of NewPipe. It provides every requested information about the current services from the user URI to video and audio URIs and the video's views and likes. NewPipe Extractor is used in other streaming applications like <a href="http://skytube-app.com/" target="_blank">SkyTube</a>.</p>
+
+            <hr class="separator" />
 
             <h4>About Team NewPipe</h4>
             <p>Team NewPipe are the main developers of the NewPipe app and the NewPipe Extractor. At December 2017 they counted eight developers who work voluntarily on this Open Source project. All work of NewPipe's developers is independent and is not funded by any company or governmental institution but by single donations of private persons.</p>
 
-            <p id="last-modified">Last modified: February 2018</p>
+            <p id="last-modified">Last modified: March 2018</p>
 
         </div>
     </div>

--- a/press/logo.html
+++ b/press/logo.html
@@ -11,7 +11,7 @@ metatitle: "Logos - NewPipe a free YouTube client"
             <h3 class="start">Logos & Icons</h3>
             {% include press_download-license-warning.html %}
             <div class="row is-flex media-gallery">
-                <div class="col-md-6" onclick="viewMediaFile(this)" data-toggle="modal" data-target="#mediaFileView" >
+                <div class="col-md-6" id="logo-team" onclick="viewMediaFile(this)" data-toggle="modal" data-target="#mediaFileView" >
                     <div class="media-file">
                         <img src="{{ site.baseurl }}/img/logo.svg" class="image-responsive" onclick="viewMediaFile(this)" />
                     </div>
@@ -23,7 +23,7 @@ metatitle: "Logos - NewPipe a free YouTube client"
                         <p class="license"><strong>License:</strong> GPLv3</p>
                     </div>
                 </div>
-                <div class="col-md-6" onclick="viewMediaFile(this)" data-toggle="modal" data-target="#mediaFileView" >
+                <div class="col-md-6" id="logo-stable" onclick="viewMediaFile(this)" data-toggle="modal" data-target="#mediaFileView" >
                     <div class="media-file">
                         <img src="{{ site.baseurl }}/img/logo_app.svg" class="image-responsive" onclick="viewMediaFile(this)" />
                     </div>
@@ -35,7 +35,7 @@ metatitle: "Logos - NewPipe a free YouTube client"
                         <p class="license"><strong>License:</strong> GPLv3</p>
                     </div>
                 </div>
-                <div class="col-md-6" onclick="viewMediaFile(this)" data-toggle="modal" data-target="#mediaFileView" >
+                <div class="col-md-6" id="logo-beta" onclick="viewMediaFile(this)" data-toggle="modal" data-target="#mediaFileView" >
                     <div class="media-file">
                         <img src="{{ site.baseurl }}/img/logo_app_beta.svg" class="image-responsive" onclick="viewMediaFile(this)" />
                     </div>

--- a/press/logo.html
+++ b/press/logo.html
@@ -6,7 +6,7 @@ metatitle: "Logos - NewPipe a free YouTube client"
 ---
 
 <main class="content">
-    <div id="welcome">
+    <div>
         <div class="container">
             <h3 class="start">Logos & Icons</h3>
             {% include press_download-license-warning.html %}

--- a/press/various.html
+++ b/press/various.html
@@ -8,7 +8,7 @@ metatitle: "Media - NewPipe a free YouTube client"
 
 
 <main class="content">
-    <div id="welcome">
+    <div>
         <div class="container">
             <h3 class="start">Additional media</h3>
             {% include press_download-license-warning.html %}


### PR DESCRIPTION
Here are some small improvements for the blog and the press kit.

- Most importantly I fixed some false links and onclick actions on the thumbnails

- I moved the post's list of categories to the text container

- Added an experimental support for linking thumbnails in the press kit to their download page. (Just go to the announcements and click the beta logo.) This can be done via the `images.yml`. Use `download:` and the absolute path to the download page / anchor.
