### PR TITLE
Blog comments improvements

### DIFF
--- a/_includes/blog_comments.html
+++ b/_includes/blog_comments.html
@@ -1,11 +1,83 @@
 <!-- TODO add data-isso -->
-<script data-isso="{{ site.isso_address }}"
+<script defer data-main="/js/embed"
+        data-isso="{{ site.isso_address }}"
         data-isso-reply-to-self="false"
         data-isso-css="false"
         data-isso-require-author="true"
         src="{{ site.isso_address }}/js/embed.min.js"></script>
+
 <div id="comments">
     <div id="comments-separator"></div>
     <h4 class="text-center">Let us know what you think!</h4>
     <section id="isso-thread"></section>
+    <div class="post-action"></div>
+    <div class="modal  fade" tabindex="-1" role="dialog" id="comments-info-modal">
+        <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title">Markdown and HTML support</h4>
+                </div>
+                <div class="modal-body">
+                    <div class="row">
+                        <div class="col-md-12">
+                            <p>Line breaks: two get line breaks, you need to make <strong>two</strong> line breaks in Markdown.</p>
+                        </div>
+                        <div class="col-md-6">
+                            <p>You can use the following options to make your comments stylish:</p>
+                            <table class="table-responsive">
+                                <tbody>
+                                <tr>
+                                    <td><strong>bold</strong></td>
+                                    <td><pre>**bold**</pre></td>
+                                </tr>
+                                <tr>
+                                    <td><em>italic</em></td>
+                                    <td><pre>*italic*</pre></td>
+                                </tr>
+                                <tr>
+                                    <td><del style="">strike</del></td>
+                                    <td><pre>~~del~~</pre></td>
+                                </tr>
+                                <tr>
+                                    <td><a href="#">link</a></td>
+                                    <td><pre>[link](https://www.example.com)</pre></td>
+                                </tr>
+                                <tr>
+                                    <td>image</td>
+                                    <td><pre>![alt text](https://www.image.com/img.png)</pre></td>
+                                </tr>
+                                <tr>
+                                    <td colspan="2">Supported headings:</td>
+                                </tr>
+                                <tr>
+                                    <td><h4>h4</h4></td>
+                                    <td><pre>#### h4</pre></td>
+                                </tr>
+                                <tr>
+                                    <td><h5>h5</h5></td>
+                                    <td><pre>##### h5</pre></td>
+                                </tr>
+                                <tr>
+                                    <td><h6>h6</h6></td>
+                                    <td><pre>###### h6</pre></td>
+                                </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div class="col-md-6">
+                            <p>Lists must have one empty line between every item:</p>
+                            <p>Bullet list:</p><pre>- something interesting<br/><br/>- also interesting</pre>
+                            <p>Ordered list:</p><pre>1. My first fact<br/><br/>2. My second fact</pre>
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <span class="pull-left">Missing something? <a href="https://github.com/TeamNewPipe/website/issues/new">Tell us!</a></span>
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
 </div>
+

--- a/css/blog.css
+++ b/css/blog.css
@@ -700,15 +700,8 @@ div.search-container button:focus, div.search-container input:focus {
   flex: 1 0 auto;
 }
 
-/* Isso comments */
-/*
-Allowed HTML Tags
-h5, h6, 
-*/
-#isso-thread .textarea:focus,
-#isso-thread input:focus {
-    border-color: #AA1D1D;
-}
+/** Comments **/
+
 #comments {
     margin-top: 20px;
     #background: #f3eff2;
@@ -725,17 +718,6 @@ h5, h6,
     margin-left: -30px;
     margin-bottom: 15px;
 }
-#comments .isso-postbox > .form-wrapper > .auth-section .post-action > input {
-    background: white;
-    padding-left: 10px;
-    padding-right: 10px;
-}
-#comments .isso-postbox > .form-wrapper > .auth-section .post-action:hover > input {
-    border-color: #AA1D1D;
-}
-#comments h1, #comments h2, #comments h3, #comments h4 {
-    font-size: 18px;
-}
 @media (min-width: 767px) {
     .comments-separator {
         width: calc(100% + 15px);
@@ -745,4 +727,92 @@ h5, h6,
         margin-top: 60px;
         margin-bottom: 75px;
     }
+}
+
+/* Isso */
+
+#comments .text-wrapper > .text {
+    float: left;
+}
+#comments .text-wrapper > .text h1, #comments .text-wrapper > .text h2,
+#comments .text-wrapper > .text h3, #comments .text-wrapper > .text h4 {
+     font-size: 18px;
+ }
+#comments .text-wrapper > .text h5 {
+    font-size: 16px;
+}
+#comments .text-wrapper > .text h6 {
+    font-size: 14px;
+}
+#comments .isso-postbox > .form-wrapper .textarea:focus,
+#comments .isso-postbox > .form-wrapper input:focus {
+    border-color: #AA1D1D;
+}
+#comments .isso-postbox {
+    display: block;
+}
+#comments .isso-postbox > .form-wrapper .text-wrapper {
+    display: inline-block;
+}
+#comments .isso-postbox > .form-wrapper .textarea-wrapper .markdown-info {
+    position: absolute;
+    z-index: 5;
+    font-size: 30px;
+    color: cornflowerblue;
+    bottom: 0;
+    line-height: 0;
+    left: 5px;
+}
+
+#comments .isso-postbox > .form-wrapper .preview .textarea {
+    display: none;
+}
+
+#comments .isso-postbox > .form-wrapper .isso-comment {
+    border: 2px solid white;
+    margin: 0 0 .3em;
+    display: none;
+}
+#comments .isso-postbox > .form-wrapper .preview .isso-comment {
+    display: block;
+}
+#comments .isso-postbox > .form-wrapper > .auth-section .post-action > * {
+    background: white;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+#comments .isso-postbox > .form-wrapper > .auth-section .post-action > *:hover {
+    border-color: #AA1D1D;
+}
+#comments .isso-postbox > .form-wrapper > .auth-section .input-wrapper,
+#comments .isso-postbox > .form-wrapper > .auth-section .post-action {
+    margin-bottom: 0.3em;
+}
+#comments .isso-postbox > .form-wrapper > .auth-section .post-action > span.info-icon {
+    line-height: 28px;
+    font-size: 20px;
+    height: 28px;
+    background: transparent;
+    float: right;
+    cursor: pointer;
+    color: #CD201F;
+    padding: 0 7px;
+}
+
+#comments-info-modal .modal-footer span {
+    line-height: 34px;
+    float: left;
+}
+#comments-info-modal table {
+    border: none;
+}
+#comments-info-modal table tr td {
+    padding-bottom: 10px;
+    padding-right: 10px;
+}
+#comments-info-modal table tr td pre {
+    margin-bottom: 0;
+    white-space: -o-pre-wrap;    /* Opera 7 */
+    white-space: pre-wrap;
+    word-wrap: break-word;
 }

--- a/css/comments.css
+++ b/css/comments.css
@@ -182,16 +182,18 @@
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 #isso-thread .textarea:focus,
-#isso-thread input:focus {
+#isso-thread input:focus,
+#isso-thread button:focus {
     border-color: #AA1D1D;
 }
 .isso-postbox > .form-wrapper > .auth-section .input-wrapper {
     display: inline-block;
     position: relative;
-    max-width: 25%;
+    max-width: 23%;
     margin: 0;
 }
-.isso-postbox > .form-wrapper > .auth-section .input-wrapper input {
+.isso-postbox > .form-wrapper > .auth-section .input-wrapper input,
+.isso-postbox > .form-wrapper > .auth-section .input-wrapper button{
     padding: .3em 10px;
     max-width: 100%;
     border-radius: 3px;
@@ -200,12 +202,14 @@
     border: 1px solid rgba(0, 0, 0, 0.2);
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
-.isso-postbox > .form-wrapper > .auth-section .post-action {
+.isso-postbox > .form-wrapper > .auth-section .post-action,
+.isso-postbox > .form-wrapper > .auth-section .input-info {
     display: inline-block;
     float: right;
     margin: 0;
 }
-.isso-postbox > .form-wrapper > .auth-section .post-action > input {
+.isso-postbox > .form-wrapper > .auth-section .post-action > input,
+.isso-postbox > .form-wrapper > .auth-section .post-action > button {
     padding: calc(.3em - 1px);
     border-radius: 2px;
     border: 1px solid #CCC;
@@ -215,10 +219,12 @@
     line-height: 1.4em;
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
-.isso-postbox > .form-wrapper > .auth-section .post-action > input:hover {
+.isso-postbox > .form-wrapper > .auth-section .post-action > input:hover,
+.isso-postbox > .form-wrapper > .auth-section .post-action > button:hover {
     background-color: #CCC;
 }
-.isso-postbox > .form-wrapper > .auth-section .post-action > input:active {
+.isso-postbox > .form-wrapper > .auth-section .post-action > input:active,
+.isso-postbox > .form-wrapper > .auth-section .post-action > button:active{
     background-color: #BBB;
 }
 @media screen and (max-width:600px) {
@@ -227,17 +233,20 @@
         max-width: 100%;
         margin: 0 0 .3em;
     }
-    .isso-postbox > .form-wrapper > .auth-section .input-wrapper input {
+    .isso-postbox > .form-wrapper > .auth-section .input-wrapper input,
+    .isso-postbox > .form-wrapper > .auth-section .input-wrapper button {
         width: 100%;
     }
-    .isso-postbox > .form-wrapper > .auth-section .post-action {
+    .isso-postbox > .form-wrapper > .auth-section .post-action,
+    .isso-postbox > .form-wrapper > .auth-section .input-info {
         display: block;
         float: none;
         text-align: right;
     }
     .isso-postbox > .form-wrapper > .textarea-wrapper,
     .isso-postbox > .form-wrapper > .auth-section .input-wrapper,
-    .isso-postbox > .form-wrapper > .auth-section .post-action {
+    .isso-postbox > .form-wrapper > .auth-section .post-action,
+    .isso-postbox > .form-wrapper > .auth-section .input-info {
         margin-bottom: 15px;
     }
 }


### PR DESCRIPTION
I added a comment preview which uses showdown.js to parse the comment on client side.

Many people who leave comments do not know they must use Markdown syntax to get there comment well formatted. Therefor I added a modal to show supported styles.

There are some small design fixes for the comments too.

@TheAssassin To introduce the preview thing and the info button, I needed to modify the isso part as well. Can you please fork isso to TeamNewPipe? People should see what we changed compared to the normal version. I didn't have time to write a smaller parser for Markdown. That's why my changes won't be included in their releases, because they blow up the file size too much.