### PR TITLE
Fix Docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll as builder
+FROM jekyll/jekyll:3 as builder
 
 COPY Gemfile /srv/jekyll
 RUN bundle install


### PR DESCRIPTION
The latest image, 4, doesn't work, there's no error message but `bundle install` fails with code 15.

@TobiGr perhaps we can upgrade to version 4 of the image. I'd like to avoid unmaintained versions.