### PR TITLE
Remove forced linebreak

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
             <div id="text-1-wrapper">
                 <div class="row">
                     <div class="col-sm-6">
-                        <p><strong>Do you like watching videos on YouTube<br>but want an intuitive, feature-rich and privacy friendly app for that?</strong></p>
+                        <p><strong>Do you like watching videos on YouTube but want an intuitive, feature-rich and privacy friendly app for that?</strong></p>
                         <p class="text-justify-md"><span class="red">NewPipe</span> has been created with the purpose of getting the original YouTube experience on your smartphone without annoying ads and questionable permissions.</p>
                         <p>The application is open source and you can check on it at <a href="https://github.com/TeamNewPipe/NewPipe/">GitHub</a>.</p>
                     </div>


### PR DESCRIPTION
Remove forced linebreak on the frontpage since there doesn't seem
to be a particularly good reason to break this sentence there.

Fixes #155