### PR TITLE
Add reading time indicator

### DIFF
--- a/_includes/reading-time.html
+++ b/_includes/reading-time.html
@@ -1,0 +1,11 @@
+{% comment %}
+inspired by https://raw.githubusercontent.com/jhvanderschee/jekyllcodex/gh-pages/_includes/reading-time.html -- thanks!
+{% endcomment %}
+
+<i class="fa fa-clock-o"></i>
+{% capture words %}
+{{ content | number_of_words | minus: 180 }}
+{% endcapture %}
+{% unless words contains '-' %}
+{{ words | plus: 150 | divided_by: 150 | append: ' minute(s)' }}
+{% endunless %}

--- a/_includes/reading-time.html
+++ b/_includes/reading-time.html
@@ -1,11 +1,22 @@
-{% comment %}
+{%- comment -%}
 inspired by https://raw.githubusercontent.com/jhvanderschee/jekyllcodex/gh-pages/_includes/reading-time.html -- thanks!
-{% endcomment %}
+{%- endcomment -%}
 
 <i class="fa fa-clock-o"></i>
-{% capture words %}
-{{ content | number_of_words | minus: 180 }}
-{% endcapture %}
-{% unless words contains '-' %}
-{{ words | plus: 150 | divided_by: 150 | append: ' minute(s)' }}
-{% endunless %}
+{% capture words -%}
+    {{ content | number_of_words | minus: 180 }}
+{%- endcapture -%}
+
+{%- if words contains '-' -%}
+    {%- assign reading_time = '1' -%}
+{%- else -%}
+    {%- capture reading_time -%}
+        {{ words | plus: 150 | divided_by: 150 }}
+    {%- endcapture -%}
+{%- endif -%}
+
+{%- if reading_time == '1' -%}
+    {{ reading_time | append: ' minute' }}
+{%- else -%}
+    {{ reading_time | append: ' minutes' }}
+{%- endif -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,6 +14,7 @@ bodyID: "blog-post"
             </time>
             {% if page.author %}
             by <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ page.author }}</span></span>
+            &ndash; {% include reading-time.html %}
         {% endif %}</p>
     </header>
 


### PR DESCRIPTION
This PR adds a reading time indicator, providing a (very, very) basic estimation based on the words count inspired by various posts on the Internet.

I would like to include this on the blog's front page, too, but I couldn't find a reliable way to do so. I suppose this is because here, we use the original(?) layout instead of overwriting it with our own in `_layouts`. But I'm not an expert for Jekyll. @TobiGr might know.