### PR TITLE
Fix 0.22.1 blogpost date

### DIFF
--- a/_posts/2022-02-25-newpipe-0.22.1.md
+++ b/_posts/2022-02-25-newpipe-0.22.1.md
@@ -2,7 +2,7 @@
 layout: post
 title: "NewPipe 0.22.1 released: Fixes and adjustments"
 short: "NewPipe 0.22.1 released"
-date: 2022-02-26 22:00:00 + 01:00
+date: 2022-02-25 22:00:00 + 01:00
 categories: [pinned, release]
 author: <a href="https://github.com/Stypox">@Stypox</a>
 image: newpipe


### PR DESCRIPTION
Instead of changing the file name to the real date (I guess that would cause problems with e.g. comments) I just made it so that the publish date inside the file corresponds to the file name (even though it is not the correct date).