### PR TITLE
Update download section

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -749,7 +749,7 @@ ul.check > li.heart:before {
 }
 
 #download1-fdroid-newpipe-repo {
-    background: #f9a728;
+    background: #ff9e1f;
     color: white;
 }
 

--- a/css/home.css
+++ b/css/home.css
@@ -748,6 +748,16 @@ ul.check > li.heart:before {
     height: 10px;
 }
 
+#download1-fdroid-newpipe-repo {
+    background: #f9a728;
+    color: white;
+}
+
+#download1-fdroid-newpipe-repo h4 {
+    color: white;
+    font-size: 25px;
+}
+
 #download-newpipe-qr-code-container-col {
     display: none;
 }
@@ -756,6 +766,22 @@ ul.check > li.heart:before {
     width: 100%;
 }
 
+#download1-fdroid,
+#download1-fdroid-newpipe-repo {
+    padding: 30px;
+}
+.download-info-content code {
+    display: block;
+    width: 100%;
+    line-break: anywhere;
+    margin-top: 5px;
+}
+#download1-apk-info {
+    padding: 10px 30px;
+}
+.download-info-content ul {
+    padding-right: 15px;
+}
 @media (min-width: 768px) {
     /* align "read more" button with "download NewPipe Legacy" button */
     /* <bad code> */
@@ -787,31 +813,70 @@ ul.check > li.heart:before {
         width: 100%;
         max-width: 12.5em;
     }
+    #download1-direct-download {
+        order: 1;
+    }
+    #download1-apk-info {
+        order: 2;
+    }
+    #download1-release-highlights {
+        order: 3;
+    }
+    #download1-installation-help {
+        order: 4;
+    }
+    #download1-fdroid-newpipe-repo {
+        order: 5;
+    }
+    #download1-fdroid {
+        order: 6;
+    }
+    .tri-col {
+        width: calc(50% - 7px / 2);
+    }
+    .tri-col:nth-child(2n - 1) {
+        margin-right: 7px !important;
+    }
+}
 
+@media (min-width: 1200px) {
+    #download1 > .row.is-flex > .tri-col {
+        width: calc((100% - (2 * 7px)) / 3);
+    }
+    /*#download1 > .row.is-flex > .tri-col:nth-child(3n - 2),*/
+    /*#download1 > .row.is-flex > .tri-col:nth-child(3n - 1) {*/
+    /*    margin-right: 7px;*/
+    /*}*/
     /* Re-order grid on medium and larger devices */
     /* Just as a British Speaker used to call in a very honourable house:Oooooorder! */
-    #download1 > .row.is-flex > [class^="col-"]:nth-child(1) {
-        order: 1;
-        width: calc(100% / 3 - 4px);
+    #download1 > .row.is-flex > #download1-direct-download {
+        order: 2;
         margin-right: 7px;
     }
-    #download1 > .row.is-flex > [class^="col-"]:nth-child(2) {
+    #download1 > .row.is-flex > #download1-release-highlights {
+        order: 1;
+        margin-right: 7px;
+    }
+    #download1 > .row.is-flex > #download1-apk-info {
+        order: 3;
+    }
+    #download1 > .row.is-flex > #download1-direct-download-legacy {
         order: 3;
         margin-right: 7px;
-        width: calc(100% / 3 - 4px);
+        width: calc(100% / 3 - 7px);
+        display: none;
     }
-    #download1 > .row.is-flex > [class^="col-"]:nth-child(3) {
-        order: 2;
-        width: calc(100% / 3 * 2 - 3px);
+    #download1 > .row.is-flex > #download1-installation-help {
+        order: 6;
     }
-    #download1 > .row.is-flex > [class^="col-"]:nth-child(4) {
-        order: 4;
-        margin-right: 7px;
-        width: calc(100% / 3 - 5px);
-    }
-    #download1 > .row.is-flex > [class^="col-"]:nth-child(5) {
+    #download1 > .row.is-flex > #download1-fdroid {
         order: 5;
-        width: calc(100% / 3 - 5px);
+        width: calc((100% - 2 * 7px) * 2 / 3 + 7px);
+        margin-right: 7px;
+    }
+    #download1 > .row.is-flex > #download1-fdroid-newpipe-repo {
+        order: 4;
+        width: calc(100%);
     }
 }
 

--- a/css/home.css
+++ b/css/home.css
@@ -770,6 +770,9 @@ ul.check > li.heart:before {
 #download1-fdroid-newpipe-repo {
     padding: 30px;
 }
+#download1-fdroid-newpipe-repo > .row.is-flex > [class*="col-"] {
+    margin-bottom: 0;
+}
 .download-info-content code {
     display: block;
     width: 100%;

--- a/css/style.css
+++ b/css/style.css
@@ -727,6 +727,12 @@ div.fdroid-col-right {
     margin: auto;
 }
 
+div.fdroid-col-right .break-line {
+    word-wrap: break-word;
+    word-wrap: anywhere;
+    line-break: anywhere;
+}
+
 #f-droid-repo-qr-code {
     display: inline-block;
 }

--- a/index.html
+++ b/index.html
@@ -525,7 +525,7 @@
 
                 <div class="col-xs-12 tile tile-bordered" id="download1">
                     <div class="row is-flex">
-                        <div class="col-xs-12 col-sm-6 col-md-4">
+                        <div class="col-xs-12 col-sm-6 col-md-6 col-lg-4 tri-col" id="download1-direct-download">
                             <div class="download-version-container">
                                 <div class="download-version-icon">
                                     <img src="img/logo_app.svg" class="img-responsive" alt="NewPipe icon" loading="lazy" />
@@ -534,96 +534,29 @@
                                     Android 5+
                                 </div>
                                 <div class="download-version-button">
-                                    <a href="https://f-droid.org/packages/org.schabi.newpipe/#latest" data-newpipe-api="flavors.github.stable.apk" data-newpipe-api-attribute="href" class="button action">
+                                    <a href="https://github.com/TeamNewPipe/NewPipe/releases" data-newpipe-api="flavors.github.stable.apk" data-newpipe-api-attribute="href" class="button action">
                                         <i class="fa fa-download"></i> NewPipe <span data-newpipe-api="flavors.github.stable.version"></span>
                                     </a>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-xs-12 col-sm-6 col-md-4">
-                            <div class="download-version-container">
-                                <div class="download-version-icon">
-                                    <img src="img/icon_legacy.svg" class="img-responsive" alt="NewPipe legacy icon" loading="lazy" />
+                        <div class="col-xs-12 col-sm-6 col-md-6 col-lg-4 tri-col" id="download1-apk-info">
+                            <div class="download-info-container">
+                                <div class="download-info-heading">
+                                    <h4>APK Info</h4>
                                 </div>
-                                <div class="download-version-requirements">
-                                    Android 4.1+
-                                </div>
-                                <div class="download-version-button">
-                                    <a href="https://f-droid.org/packages/org.schabi.newpipelegacy/#latest" data-newpipe-api="flavors.fdroid_legacy.stable.apk" data-newpipe-api-attribute="href" class="button action">
-                                        <i class="fa fa-download"></i> NewPipe legacy <span data-newpipe-api="flavors.fdroid_legacy.stable.version"></span>
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-xs-12 col-sm-12 col-md-8">
-                            <div id="download-info-carousel-container">
-                                <div id="f-droid-carousel" class="carousel slide" data-ride="carousel" data-interval="6000">
-
-                                    <!-- Wrapper for slides -->
-                                    <div class="carousel-inner" role="listbox">
-                                        <div class="item active">
-                                            <p><a href="https://f-droid.org/"><img src="img/fdroid-logo.svg" class="img-responsive fdroid-logo" alt="F-Droid logo" loading="lazy" /> F-Droid</a> is a trusted catalogue of Free and Open Source applications for Android.</p>
-                                            <p>Install the F-Droid app to get notified about updates. It enables you to download and update them too.</p>
-											<div>
-											<p>If you install NewPipe via the default F-Droid repo, updates for NewPipe might take their time to arrive for you. If you want to use our own repository, check out the next item in this slideshow.</p>
-                                            <a href="https://f-droid.org/packages/org.schabi.newpipe/" target="_blank">
-											<img src="/img/f-droid.svg" class="f-droid" alt="get it on F-Droid" loading="lazy" /></a>
-											</div>
-                                            <p><a href=" https://f-droid.org/en/about/#terms-etc">F-Droid respects your privacy. They don’t track you, or your device.</a><br />
-                                                We would like to thank them for providing their services in this way.
-                                            </p>
-                                        </div>
-                                        <div class="item">
-                                            <div class="row is-flex">
-                                                <div class="col-md-5 col-lg-4" id="download-newpipe-qr-code-container-col">
-                                                    <div id="download-newpipe-qr-code-container">
-                                                        <a href="https://archive.newpipe.net/fdroid/repo/?fingerprint=E2402C78F9B97C6C89E97DB914A2751FDA1D02FE2039CC0897A462BDB57E7501">
-                                                            <img src="/img/fdroid-repo-qrcode.svg" class="img-responsive fdroid-repo-qrcode" alt="Link to our F-Droid repo" loading="lazy">
-                                                        </a>
-                                                    </div>
-                                                </div>
-                                                <div class="col-md-7 col-lg-8">
-                                                    <div class="fdroid-col-right">
-                                                        <p>You can also add our F-Droid repository to your client to receive updates even faster.</p>
-                                                        <p><a class="break-line" href="https://archive.newpipe.net/fdroid/repo/?fingerprint=E2402C78F9B97C6C89E97DB914A2751FDA1D02FE2039CC0897A462BDB57E7501">https://archive.newpipe.net/fdroid/repo/?fingerprint=E2402C78F9B97C6C89E97DB914A2751FDA1D02FE2039CC0897A462BDB57E7501</a></p>
-                                                        <div class="hidden-md hidden-lg">
-                                                            <p id="f-droid-qr-code-toggle" class="text-center"><i class="fa fa-chevron-right"></i> <span class="f-droid-qr-code-toggled shown">Show</span><span class="f-droid-qr-code-toggled hidden">Hide</span> QR-code</p>
-                                                            <p class="text-center">
-                                                                <a id="f-droid-repo-qr-code" href="https://archive.newpipe.net/fdroid/repo/?fingerprint=E2402C78F9B97C6C89E97DB914A2751FDA1D02FE2039CC0897A462BDB57E7501" class="hidden f-droid-qr-code-toggled">
-                                                                    <img src="/img/fdroid-repo-qrcode.svg" class="img-responsive" alt="Link to our F-Droid repo" loading="lazy"/>
-                                                                </a>
-                                                            </p>
-                                                        </div>
-                                                        <p class="text-center text-left-md"><a class="button button-small action grey" href="{{ site.baseurl }}/FAQ/tutorials/install-add-fdroid-repo/">Learn more</a></p>
-
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-
-                                    <!-- Indicators -->
-                                    <ol class="carousel-indicators">
-                                        <li data-target="#f-droid-carousel" data-slide-to="0" class="active"></li>
-                                        <li data-target="#f-droid-carousel" data-slide-to="1"></li>
-                                    </ol>
-
-                                    <!-- Controls: not displayed but needed to get preventJumpingPage() working
-                                         Pausing the Carousel won't work without controls. Don't ask me why :)
-                                     -->
-                                    <a class="left carousel-control" href="#f-droid-carousel" role="button" data-slide="prev">
-                                        <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
-                                        <span class="sr-only">Previous</span>
-                                    </a>
-                                    <a class="right carousel-control" href="#f-droid-carousel" role="button" data-slide="next">
-                                        <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
-                                        <span class="sr-only">Next</span>
-                                    </a>
-
+                                <div class="download-info-content">
+                                    <p><span data-newpipe-api="github-hash-type">SHA256</span>:
+                                        <code data-newpipe-api="github-hash">c5d411aa177d0209dd9b0e0c163c430f92c47ab3599b8118a2d0039526399185</code>
+                                    </p>
+                                    <p>
+                                    Signing key:
+                                        <code>B0:2E:90:7C:1C:D6:FC:57:C3:35:F0:88:D0:8F:50:5F:94:E4:D2:15</code>
+                                    </p>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-xs-12 col-sm-12 col-md-4">
+                        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4 tri-col" id="download1-release-highlights">
                             <div class="download-info-container">
                                 <div class="download-info-heading">
                                     <h4>Release Highlights</h4>
@@ -638,7 +571,47 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-xs-12 col-sm-12 col-md-4">
+                        <div class="col-xs-12 col-sm-12 col-md-12" id="download1-fdroid-newpipe-repo">
+                            <div class="row is-flex">
+                                <div class="col-md-5 col-lg-4" id="download-newpipe-qr-code-container-col">
+                                    <div id="download-newpipe-qr-code-container">
+                                        <a href="https://archive.newpipe.net/fdroid/repo/?fingerprint=E2402C78F9B97C6C89E97DB914A2751FDA1D02FE2039CC0897A462BDB57E7501">
+                                            <img src="/img/fdroid-repo-qrcode.svg" class="img-responsive fdroid-repo-qrcode" alt="Link to our F-Droid repo" />
+                                        </a>
+                                    </div>
+                                </div>
+                                <div class="col-md-7 col-lg-8">
+                                    <div class="fdroid-col-right">
+                                        <h4>Faster updates</h4>
+                                        <p>You can also add our own F-Droid repository to your client to receive updates even faster.</p>
+                                        <p><a class="break-line" href="https://archive.newpipe.net/fdroid/repo/?fingerprint=E2402C78F9B97C6C89E97DB914A2751FDA1D02FE2039CC0897A462BDB57E7501">https://archive.newpipe.net/fdroid/repo/?fingerprint=E2402C78F9B97C6C89E97DB914A2751FDA1D02FE2039CC0897A462BDB57E7501</a></p>
+                                        <div class="hidden-md hidden-lg">
+                                            <p id="f-droid-qr-code-toggle" class="text-center"><i class="fa fa-chevron-right"></i> <span class="f-droid-qr-code-toggled shown">Show</span><span class="f-droid-qr-code-toggled hidden">Hide</span> QR-code</p>
+                                            <p class="text-center">
+                                                <a id="f-droid-repo-qr-code" href="https://archive.newpipe.net/fdroid/repo/?fingerprint=E2402C78F9B97C6C89E97DB914A2751FDA1D02FE2039CC0897A462BDB57E7501" class="hidden f-droid-qr-code-toggled">
+                                                    <img src="https://f-droid.org/assets/download-fdroid-qr.png" class="img-responsive" alt="URL to our F-Droid repo"/>
+                                                </a>
+                                            </p>
+                                        </div>
+                                        <p class="text-center text-left-md"><a class="button button-small action grey" href="{{ site.baseurl }}/FAQ/tutorials/install-add-fdroid-repo/">Learn more</a></p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-xs-12 col-sm-12 col-md-12" id="download1-fdroid">
+                            <p><a href="https://f-droid.org/"><img src="img/fdroid-logo.svg" class="img-responsive fdroid-logo" alt="F-Droid logo" /> F-Droid</a> is a trusted catalogue of Free and Open Source applications for Android.</p>
+                            <p>Install the F-Droid app to get notified about updates. It enables you to download and update them too.</p>
+                            <div>
+                                <p>If you install NewPipe via the default F-Droid repo, updates for NewPipe might take their time to arrive for you. If you want to use our own repository, check out the next item in this slideshow.</p>
+                                <a href="https://f-droid.org/packages/org.schabi.newpipe/" target="_blank">
+                                    <img src="/img/f-droid.svg" class="f-droid" alt="get it on F-Droid">
+                                </a>
+                            </div>
+                            <p><a href=" https://f-droid.org/en/about/#terms-etc">F-Droid respects your privacy. They don’t track you, or your device.</a><br />
+                                We would like to thank them for providing their services in this way.
+                            </p>
+                        </div>
+                        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-4 tri-col" id="download1-installation-help">
                             <div class="download-info-container">
                                 <div class="download-info-heading">
                                     <h4>Need help?</h4>

--- a/index.html
+++ b/index.html
@@ -534,8 +534,8 @@
                                     Android 5+
                                 </div>
                                 <div class="download-version-button">
-                                    <a href="https://github.com/TeamNewPipe/NewPipe/releases" data-newpipe-api="flavors.github.stable.apk" data-newpipe-api-attribute="href" class="button action">
-                                        <i class="fa fa-download"></i> NewPipe <span data-newpipe-api="flavors.github.stable.version"></span>
+                                    <a href="https://github.com/TeamNewPipe/NewPipe/releases" data-newpipe-api="flavors.newpipe.apk" data-newpipe-api-attribute="href" class="button action">
+                                        <i class="fa fa-download"></i> NewPipe <span data-newpipe-api="flavors.newpipe.version"></span>
                                     </a>
                                 </div>
                             </div>
@@ -546,8 +546,8 @@
                                     <h4>APK Info</h4>
                                 </div>
                                 <div class="download-info-content">
-                                    <p><span data-newpipe-api="github-hash-type">SHA256</span>:
-                                        <code data-newpipe-api="github-hash">c5d411aa177d0209dd9b0e0c163c430f92c47ab3599b8118a2d0039526399185</code>
+                                    <p>Hash sum: <span data-newpipe-api="flavors.newpipe.hash_type">hashing algorithm not available</span>
+                                        <code data-newpipe-api="flavors.newpipe.hash">hash sum not available</code>
                                     </p>
                                     <p>
                                     Signing key:

--- a/js/tiles.js
+++ b/js/tiles.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
     let $carousel = $(".carousel");
     $carousel.carousel();
-    let carousels = {0: "user-voices-carousel", 1: "f-droid-carousel"};
+    let carousels = {0: "user-voices-carousel"};
     let paused = {};
     for (let key in carousels) {
         if (!carousels.hasOwnProperty(key)) continue;

--- a/js/web-api.js
+++ b/js/web-api.js
@@ -13,7 +13,7 @@
  *
  *  Example usage:
  *  <pre>
- *  <a href="https://default.locati.on" data-newpipe-api="flavors.fdroid.stable.apk" data-newpipe-api-attribute="href">
+ *  <a href="https://default.locati.on" data-newpipe-api="flavors.newpipe.apk" data-newpipe-api-attribute="href">
  *      download APK</a>
  *  </pre>
  */
@@ -45,7 +45,7 @@ function updateWithAPIData(object, key, oldIdentifier) {
 
         // get all elements which registered to be updated with the API data
         let elementsToUpdate = document.querySelectorAll('[data-newpipe-api="' + newIdentifier + '"]');
-        if (elementsToUpdate == null) return;
+        if (elementsToUpdate == null || elementsToUpdate.length === 0) return;
 
         let data = object.toString();
         for (let i = 0; i < elementsToUpdate.length; i++) {

--- a/press/index.html
+++ b/press/index.html
@@ -15,7 +15,7 @@ metatitle: "Press information - NewPipe a free YouTube client"
             <p class="good-user-experience">A good user experience is important to the developers of NewPipe. Therefore, the app offers many solutions for all possible situations. In this way, the resolution and codecs of the video and audio can be set to save data volume in mobile networks. Likewise, NewPipe's video popup and background players make it possible to seamlessly integrate videos and music into daily mobile phone use.</p>
             <p><strong>Quick information:</strong></p>
             <ul>
-                <li>Current stable version: <span data-newpipe-api="flavors.fdroid.stable.version">0.25.2 (Effective 2th September 2023)</span></li>
+                <li>Current stable version: <span data-newpipe-api="flavors.newpipe.version">0.25.2 (Effective 2th September 2023)</span></li>
                 <li>Initial release: 4. September 2015</li>
                 <li>Founder: Christian Schabesberger</li>
                 <li class="linebreak">Available translations: <span data-newpipe-api="stats.translations">110</span><br>You can find a list with all current supported languages at <a href="https://hosted.weblate.org/projects/newpipe/#languages" target="_blank">Weblate</a>.</li>


### PR DESCRIPTION
This PR updates the download section.
- Remove the option to download the legacy version
- Add information on the APK (hash sums, signer)
- Make the info on our F-Droid repo more visible and move it from the slider into an own highlighted box
- Reorder some boxes
- Update some default values in case the API is not available

Requires TeamNewPipe/web-api#17 to be merged.
~~Related: https://gitlab.com/fdroid/fdroid-website/-/merge_requests/841~~

<details><summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/17365767/188312724-717920b4-2459-4903-a364-38b214ba0fd0.png"/>
</details>