### PR TITLE
Fix the link to the matrix bridged room

### DIFF
--- a/press/contact.html
+++ b/press/contact.html
@@ -24,7 +24,7 @@ metatitle: "Contact - NewPipe a free YouTube client"
             <p class="large-linebreak">The IRC Libera.Chat channel for asking quick questions and direct communication between our developers is <a href="https://web.libera.chat/#newpipe">#newpipe</a>.</p>
 
             <p><strong>Matrix</strong></p>
-            <p class="large-linebreak">The Matrix room <a href="https://matrix.to/#/">#newpipe:libera.chat</a> is connected via a bridge with the IRC channel.</p>
+            <p class="large-linebreak">The Matrix room <a href="https://matrix.to/#/#newpipe:libera.chat">#newpipe:libera.chat</a> is connected via a bridge with the IRC channel.</p>
 
             <p id="last-modified">Last modified: July 2023</p>
 


### PR DESCRIPTION
The link was pointed to matrix.to itself