### PR TITLE
Do not list Schabi as the email holder

### DIFF
--- a/press/contact.html
+++ b/press/contact.html
@@ -11,8 +11,7 @@ metatitle: "Contact - NewPipe a free YouTube client"
         <div class="container">
             <h3 class="red start">Contact</h3>
 
-            <p>For press enquiries please contact Christian Schabesberger via email.</p>
-            <p class="large"><strong>Christian Schabesberger</strong></p>
+            <p>For press enquiries please contact the NewPipe team via email.</p>
             <p><strong>Email:</strong> <a href="mailto:team@newpipe.net">team@newpipe.net</a></p>
             <br><br>
 


### PR DESCRIPTION
I was wondering why we keep getting emails at `team@newpipe.n et` from people saying "Hello Christian Schabesberger", although Schabi is not responsible for that email anymore. Then I found out we still list Schabi as the email holder under the Contact page.