### PR TITLE
Use https for external URLs and update SIL OFL URL

### DIFF
--- a/legal/license.html
+++ b/legal/license.html
@@ -62,12 +62,12 @@ Copyright Dave Gandy.</p>
 <p>The source code (CSS files etc.) is licensed under the terms of the MIT
 license.</p>
 
-<p>The details can be found on the <a href="http://fontawesome.io/license/">
+<p>The details can be found on the <a href="https://fontawesome.io/license/">
 Font Awesome homepage</a>.</p>
 
 <p>You can fetch a copy of these licenses from the "licenses" directory
 inside this repository as well as from the
-<a href="http://scripts.sil.org/OFL">SIL homepage</a> and the
+<a href="https://openfontlicense.org/open-font-license-official-text/">Open Font License homepage</a> and the
 <a href="https://opensource.org/licenses/MIT">Open Source Initiative's
 homepage</a>.</p>
 


### PR DESCRIPTION
Also update the URL to the SIL OFL license text.