### PR TITLE
Link to bank's imprint on donate page

### DIFF
--- a/donate/index.html
+++ b/donate/index.html
@@ -72,7 +72,7 @@ footerBuffer: "True"
                                                 <tbody>
                                                     <tr><th scope="row">Account holder:</th><td>NewPipe e.V.</td></tr>
                                                     <tr><th scope="row">IBAN:</th><td>DE94 4306 0967 1308 7563 00</td></tr>
-                                                    <tr><th scope="row">Bank:</th><td>GLS Gemeinschaftsbank eG</td></tr>
+                                                    <tr><th scope="row">Bank:</th><td><a href="https://www.gls.de/impressum/">GLS Gemeinschaftsbank eG</a></td></tr>
                                                     <tr><th scope="row">BIC:</th><td>GENODEM1GLS</td></tr>
                                                 </tbody>
                                             </table>


### PR DESCRIPTION
Some users may want to know the address of our bank; this convenience link provides it to them without occupying any space on the website.