### PR TITLE
Adjust wording around donations

### DIFF
--- a/css/donate.css
+++ b/css/donate.css
@@ -109,7 +109,16 @@ main .row [class^="col"] {
 
 #bank-transfer-donation h4 {
     font-weight: bold;
+    margin-bottom: 0;
 }
+
+#bank-transfer-donation .subtitle {
+    font-size: 8pt;
+    font-weight: normal;
+    opacity: 0.9;
+    margin-bottom: 10px;
+}
+
 
 #bank-transfer-donation th {
     padding-right: 1rem;

--- a/donate/index.html
+++ b/donate/index.html
@@ -18,7 +18,7 @@ footerBuffer: "True"
                 </div>
                 <div class="col-sm-10 col-sm-push-1 col-md-6 col-md-push-0">
                     <p class="red donate-section-title"><strong><img src="../img/people-red.svg" class="people-large">&nbsp;&nbsp;We put donations to good use</strong></p>
-                    <p>The donations are handled by <a href="https://newpipe-ev.de">NewPipe e.V.</a>, which hires developers to work on NewPipe, buys merch for contributors, sends representatives to open source conferences, supports libre media streaming technology, <a href="https://newpipe-ev.de/blog/">and more</a>.</p>
+                    <p>Donations are handled by <a href="https://newpipe-ev.de">NewPipe e.V.</a>, which hires developers to work on NewPipe, buys merch for contributors, sends representatives to open source conferences, supports libre media streaming technology, <a href="https://newpipe-ev.de/budget/2026/">and more</a>.</p>
                 </div>
             </div>
         </div>
@@ -43,7 +43,7 @@ footerBuffer: "True"
                         <div class="row" id="sorted-row">
                             <div class="col-sm-12" id="donate-title">
                                 <h3 class="with-subtitle">Do you like what we did so far?</h3>
-                                <p class="subtitle">Help us to bring NewPipe forward!</p>
+                                <p class="subtitle">Help us bring NewPipe forward!</p>
                             </div>
                             <div class="col-xs-12 col-lg-10" id="button-container">
                                 <div class="row" style="width: 100%;">
@@ -60,7 +60,7 @@ footerBuffer: "True"
                                             <a href="https://www.paypal.com/donate/?hosted_button_id=MZXL7WW8DXZBJ" target="_blank"
                                                class="button button-large action donate" title="Donate to NewPipe via PayPal">
                                                 PayPal
-                                                <div class="donate-action-subtitle">(higher fees)</div>
+                                                <div class="donate-action-subtitle">(very high fees)</div>
                                             </a>
                                         </div>
                                     </div>
@@ -68,12 +68,14 @@ footerBuffer: "True"
                                     <div class="col-sm-12">
                                         <div class="button-wrapper button action donate" id="bank-transfer-donation">
                                             <h4>Bank transfer</h4>
+                                            <div class="subtitle">(lowest fees)</div>
                                             <table>
                                                 <tbody>
                                                     <tr><th scope="row">Account holder:</th><td>NewPipe e.V.</td></tr>
                                                     <tr><th scope="row">IBAN:</th><td>DE94 4306 0967 1308 7563 00</td></tr>
                                                     <tr><th scope="row">Bank:</th><td><a href="https://www.gls.de/impressum/">GLS Gemeinschaftsbank eG</a></td></tr>
                                                     <tr><th scope="row">BIC:</th><td>GENODEM1GLS</td></tr>
+                                                    <tr><th scope="row">Reason for transfer:</th><td>NewPipe donation</td></tr>
                                                 </tbody>
                                             </table>
                                         </div>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
         <div class="container container-double">
             <div class="row is-flex">
                 <div class="col-md-9 feature-detail" id="lightweight">
-                    <h3 class="newpipe-title">NewPipe - the smart streaming solution</h3>
+                    <h3 class="newpipe-title">NewPipe – the smart streaming solution</h3>
                     <div class="feature-description">
                         <div class="row">
 
@@ -727,7 +727,7 @@
                 <div class="col-md-6 tile tile-right" id="tile-like-np">
                     <h4>Like the idea?</h4>
                     <p>We hope so! But don't forget, a lot of time and energy goes into this, and we share it with you.</p>
-                    <p>We offer you ways to support our work by donations - so we can get some <strong class="red">extra snacks during work!</strong></p>
+                    <p>We offer you ways to support our work by donations – so we can <strong class="red">supercharge development with paid development hours!</strong></p>
                 </div>
 
             </div>


### PR DESCRIPTION
On behalf of NewPipe e.V., I suggest the following changes:

- add reason for transfer (regulatory reasons)
- further discourage PayPal use, mention that bank account transfers have lowest fees
- adjust some phrasings to more accurately represent what the e.V. does with money
- randomly replace a hyphen with an en dash to make the page look more <del>AI generated</del> professionally typeset

<img width="667" height="483" alt="image" src="https://github.com/user-attachments/assets/f2118943-40e6-41b2-be97-3febe3c4ecd5" />
